### PR TITLE
Small fix for duplicate 'VAT' assignation

### DIFF
--- a/src/DataType/CategoryTradeTax.php
+++ b/src/DataType/CategoryTradeTax.php
@@ -15,7 +15,7 @@ class CategoryTradeTax
     /**
      * BT-95-0.
      */
-    private string $typeCode = 'VAT';
+    private string $typeCode;
 
     /**
      * BT-95.


### PR DESCRIPTION
Small fix for duplicate 'VAT' assignation